### PR TITLE
깃 액션을 통한 CI/CD 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+*.env
+*.ini
+*.md
+.cache
+.git
+.github
+.vscode
+migrations
+__pycache__

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -1,0 +1,70 @@
+name: Build and Push Docker Image
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/test:${{ env.RELEASE_VERSION }}
+
+  Deploy:
+    needs: build-and-push-image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+
+      - name: copy file via ssh password
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.NCP_HOST }}
+          username: ${{ secrets.NCP_USERNAME }}
+          port: ${{ secrets.NCP_PORT }}
+          key: ${{ secrets.PRIVATE_KEY }}
+          source: "deploy/*"
+          target: "/root/jw/git-action"
+
+      - name: Deploy
+        uses: appleboy/ssh-action@master
+        env:
+          SERVER_PORT: 7000
+          RELOAD: ${{ secrets.RELOAD }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+        with:
+          host: ${{ secrets.NCP_HOST }}
+          port: ${{ secrets.NCP_PORT }}
+          username: ${{ secrets.NCP_USERNAME }}
+          key: ${{ secrets.PRIVATE_KEY }}
+          envs: SERVER_PORT, RELOAD, DOCKERHUB_USERNAME, RELEASE_VERSION
+          script: |
+            export SERVER_PORT=$SERVER_PORT
+            export RELOAD=$RELOAD
+            export DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME
+            export RELEASE_VERSION=$RELEASE_VERSION
+            sh /root/jw/git-action/deploy/deploy.sh

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -1,70 +1,66 @@
-name: Build and Push Docker Image
+name: CI/CD
 on:
   push:
     tags:
       - "v*"
 jobs:
-  build-and-push-image:
+  CI:
     runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.setenv.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+      - id: setenv
+        name: Set env
+        run: echo "::set-output name=tag::${GITHUB_REF#refs/*/v}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to DockerHub
+      - name: Login to NCP Container Registry
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.NCP_ACCESS_KEY }}
+          password: ${{ secrets.NCP_SECRET_KEY }}
+          registry: ${{ secrets.NCP_REG_ENDPOINT }}
 
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/test:${{ env.RELEASE_VERSION }}
+          tags: ${{ secrets.NCP_REG_ENDPOINT }}/cafe-search:${{ steps.setenv.outputs.tag }}
 
-  Deploy:
-    needs: build-and-push-image
+  CD:
+    needs: CI
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
-
-      - name: copy file via ssh password
-        uses: appleboy/scp-action@master
+      - name: Login to NCP Container Registry
+        uses: docker/login-action@v1
         with:
-          host: ${{ secrets.NCP_HOST }}
-          username: ${{ secrets.NCP_USERNAME }}
-          port: ${{ secrets.NCP_PORT }}
-          key: ${{ secrets.PRIVATE_KEY }}
-          source: "deploy/*"
-          target: "/root/jw/git-action"
+          username: ${{ secrets.NCP_ACCESS_KEY }}
+          password: ${{ secrets.NCP_SECRET_KEY }}
+          registry: ${{ secrets.NCP_REG_ENDPOINT }}
 
       - name: Deploy
-        uses: appleboy/ssh-action@master
+        working-directory: ./deploy
         env:
-          SERVER_PORT: 7000
-          RELOAD: ${{ secrets.RELOAD }}
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-        with:
-          host: ${{ secrets.NCP_HOST }}
-          port: ${{ secrets.NCP_PORT }}
-          username: ${{ secrets.NCP_USERNAME }}
-          key: ${{ secrets.PRIVATE_KEY }}
-          envs: SERVER_PORT, RELOAD, DOCKERHUB_USERNAME, RELEASE_VERSION
-          script: |
-            export SERVER_PORT=$SERVER_PORT
-            export RELOAD=$RELOAD
-            export DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME
-            export RELEASE_VERSION=$RELEASE_VERSION
-            sh /root/jw/git-action/deploy/deploy.sh
+          SERVER_PORT: 8000
+          RELOAD: 0
+          RELEASE_VERSION: ${{ needs.CI.outputs.image-tag }}
+          NCP_REG_ENDPOINT: ${{ secrets.NCP_REG_ENDPOINT }}
+          NCP_DOCKER_HOST: ${{ secrets.NCP_HOST }}
+          NCP_DOCKER_PORT: ${{ secrets.NCP_DOCKER_PORT }}
+          CA_CERT: ${{ secrets.DOCKER_CA_CERT }}
+          CERT: ${{ secrets.DOCKER_CERT }}
+          KEY: ${{ secrets.DOCKER_KEY }}
+        run: |
+          echo -n "$CA_CERT" | base64 --decode > ca.pem
+          echo -n "$CERT" | base64 --decode > cert.pem
+          echo -n "$KEY" | base64 --decode > key.pem
+          sh deploy.sh

--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
+*.ini
 .env
 .venv
 env/
@@ -133,7 +134,7 @@ dmypy.json
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json
-!.vscode/launch.jsonK
+!.vscode/launch.json
 !.vscode/extensions.json
 !.vscode/*.code-snippets
 
@@ -151,3 +152,4 @@ dmypy.json
 # Support for Project snippet scope
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode
+migrations/

--- a/.gitignore
+++ b/.gitignore
@@ -152,8 +152,4 @@ dmypy.json
 # Support for Project snippet scope
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode
-<<<<<<< HEAD
-=======
-
->>>>>>> 5cba2f85456f925b4205182e3be04cab36a01907
 migrations/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.8-slim-buster
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install -r requirement.txt
+
+CMD ["python", "app/main.py"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,27 @@
 import uvicorn
 from fastapi import FastAPI
+from pydantic import BaseSettings
 
 
 app = FastAPI()
 
-if __name__ == '__main__':
-    uvicorn.run('app.main:app', host='localhost', port=8000, reload=True)
+
+class ServerSettings(BaseSettings):
+    SERVER_HOST: str = "0.0.0.0"
+    SERVER_PORT: int = 7000
+    RELOAD: bool = True
+
+
+@app.get("/health")
+async def health_check():
+    return {"status": "UP"}
+
+
+if __name__ == "__main__":
+    server = ServerSettings()
+    uvicorn.run(
+        "main:app",
+        host=server.SERVER_HOST,
+        port=server.SERVER_PORT,
+        reload=server.RELOAD,
+    )

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+APP_NAME=cafe-search
+DEPLOY_DIR=/root/jw/git-action/deploy
+
+EXIST_BLUE=$(docker-compose -p ${APP_NAME}-blue -f ${DEPLOY_DIR}/docker-compose-blue.yml ps | grep Up)
+
+if [ -z "$EXIST_BLUE" ]; then
+    echo "blue up"
+    IDLE_PORT=8000
+    docker-compose -p ${APP_NAME}-blue -f ${DEPLOY_DIR}/docker-compose-blue.yml up -d
+
+else
+    echo "green up"
+    IDLE_PORT=8001
+    docker-compose -p ${APP_NAME}-green -f ${DEPLOY_DIR}/docker-compose-green.yml up -d
+fi 
+
+echo "> Health check 시작합니다."
+echo "> curl -s http://0.0.0.0:$IDLE_PORT/health"
+sleep 1
+
+for retry_count in {1..100}
+do
+response=$(curl -s http://0.0.0.0:$IDLE_PORT/health)
+up_count=$(echo $response | grep 'UP' | wc -l)
+
+if [ $up_count -ge 1 ]
+then
+    echo "> Health check 성공"
+    break
+else
+    echo "> Health check: ${response}"
+fi
+
+if [ $retry_count -eq 100 ]
+then
+    echo "> Health check 실패. "
+    echo "> Nginx에 연결하지 않고 배포를 종료합니다."
+    exit 1
+fi
+done
+
+docker exec -it proxy sh /scripts/switch-serve.sh ${IDLE_PORT}
+docker exec -it proxy service nginx reload
+
+if [ -z "$EXIST_BLUE" ]; then
+    docker-compose -p ${APP_NAME}-green -f ${DEPLOY_DIR}/docker-compose-green.yml down
+
+else
+    docker-compose -p ${APP_NAME}-blue -f ${DEPLOY_DIR}/docker-compose-blue.yml down
+fi
+echo "> 배포 성공 Nginx Current Proxy Port: $IDLE_PORT"
+exit 0

--- a/deploy/docker-compose-blue.yml
+++ b/deploy/docker-compose-blue.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+
+services:
+  test:
+    image: ${DOCKERHUB_USERNAME}/test:${RELEASE_VERSION}
+    ports:
+      - 8000:${SERVER_PORT}
+    environment:
+      SERVER_PORT: ${SERVER_PORT}
+      RELOAD: ${RELOAD}

--- a/deploy/docker-compose-blue.yml
+++ b/deploy/docker-compose-blue.yml
@@ -2,9 +2,9 @@ version: "3.8"
 
 services:
   test:
-    image: ${DOCKERHUB_USERNAME}/test:${RELEASE_VERSION}
+    image: $NCP_REG_ENDPOINT/$APP_NAME:$RELEASE_VERSION
     ports:
-      - 8000:${SERVER_PORT}
+      - 8000:$SERVER_PORT
     environment:
-      SERVER_PORT: ${SERVER_PORT}
-      RELOAD: ${RELOAD}
+      SERVER_PORT: $SERVER_PORT
+      RELOAD: $RELOAD

--- a/deploy/docker-compose-green.yml
+++ b/deploy/docker-compose-green.yml
@@ -2,9 +2,9 @@ version: "3.8"
 
 services:
   test:
-    image: ${DOCKERHUB_USERNAME}/test:${RELEASE_VERSION}
+    image: $NCP_REG_ENDPOINT/$APP_NAME:$RELEASE_VERSION
     ports:
-      - 8001:${SERVER_PORT}
+      - 8001:$SERVER_PORT
     environment:
-      SERVER_PORT: ${SERVER_PORT}
-      RELOAD: ${RELOAD}
+      SERVER_PORT: $SERVER_PORT
+      RELOAD: $RELOAD

--- a/deploy/docker-compose-green.yml
+++ b/deploy/docker-compose-green.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+
+services:
+  test:
+    image: ${DOCKERHUB_USERNAME}/test:${RELEASE_VERSION}
+    ports:
+      - 8001:${SERVER_PORT}
+    environment:
+      SERVER_PORT: ${SERVER_PORT}
+      RELOAD: ${RELOAD}


### PR DESCRIPTION
Git Action on tag("v*") push 
# CI
1. 저장소에 있는 코드 체크아웃
2. docker image tag 를 위해 GITHUB_ENV 환경 변수 중 tag의 정보만 RELEASE_VERSION에 저장
3. Git secret의 NCP_API_KEY, NCP_SECRET_KEY, END_POINT 로 NCP Container Registry에 로그인
4.  저장소에 존재하는 Dockerfile로 docker image build 후  NCP Container Registry에 push

# CD
1. 저장소에 있는 코드 체크아웃
2. Git secret의 NCP_API_KEY, NCP_SECRET_KEY, END_POINT 로 NCP Container Registry에 로그인
3. 배포 스크립트로 dockerd TLS 통신을 통한 원격 배포

# 배포 스크립트
1. 중단 없이 배포하기 위해 서로 다른 포트를 가진 웹 서버 docker compose 준비.
3. 서버 앞 단에 nginx를 proxy 서버로 이용한다.
4. 새로 배포 된 이미지를 이용해 기존에 동작하지 않는 (IDLE_PORT)의 컨테이너를 실행한다.
5. 서버에 요청을 보내서 응답이 정상적으로 오는지 확인한다. (health_check)
6. proxy 서버에 설정을 수정하여 새로운 서버 포트를 바라보게 한다.
7. 기존의 서버를 내린다. 

# 고민해볼것.
blue, green 배포 전략을 통해 무중단 배포를 하고 싶었는데 못했습니다.
지금은 두 개의 포트가 고정이라서 번갈아 가면서 배포를 할 수 있는데 
서버 그룹의 숫자가 늘어나거나 에러로 인해 롤백이 필요할 땐 현재 방법을 못 사용합니다.
-> 쿠버네티스로 모든 문제를 해결 가능할 것 같습니다.

현재는 단순 서버 실행만 했는데 나중에 db 연결이나 외부 통신이 많아지면 health check 하는 
방법을 더 고도화 해야 할 것 같습니다. 
